### PR TITLE
Split out configuration items into separate files

### DIFF
--- a/mysqlbkup.cnf.sample
+++ b/mysqlbkup.cnf.sample
@@ -1,0 +1,9 @@
+[mysql]
+host=dbhost
+user=dba
+password=dba_passwd
+
+[mysqldump]
+host=dbhost
+user=dba
+password=dba_passwd

--- a/mysqlbkup.cnf.sample
+++ b/mysqlbkup.cnf.sample
@@ -7,3 +7,8 @@ password=dba_passwd
 host=dbhost
 user=dba
 password=dba_passwd
+force
+opt
+routines
+triggers
+max_allowed_packet=250M 

--- a/mysqlbkup.config.sample
+++ b/mysqlbkup.config.sample
@@ -1,0 +1,22 @@
+##########
+# Configuration file for mysqlbkup
+# https://github.com/quickshiftin/mysqlbkup
+##########
+
+DEFAULTS_FILE=/etc/mysqlbkup.cnf
+
+BACKUP_DIR=/var/mysqlbkup
+
+MAX_BACKUPS=3
+
+# Databases to ignore
+# This is a space separated list.
+# Each entry supports bash pattern matching by default.
+# You may use POSIX regular expressions for a given entry by prefixing it with a tilde.
+DB_EXCLUDE_FILTER=
+
+# Compression library
+BKUP_BIN=gzip # Change this to xz if you wish, for tighter compression
+BKUP_EXT=gz   # Change this to xz if you wish, for tighter compression
+
+

--- a/mysqlbkup.sh
+++ b/mysqlbkup.sh
@@ -21,8 +21,8 @@
 # --------------------------------------------------------------------------------
 
 # mysql server info ------------------------------------------
-if [ -e /etc/mysqlbkup ]; then
-    . /etc/mysqlbkup
+if [ -e /etc/mysqlbkup.config ]; then
+    . /etc/mysqlbkup.config
 fi
 
 if [ -z "$DEFAULTS_FILE" ]; then
@@ -85,7 +85,7 @@ done
 date=$(date +%F)
 
 # get the list of dbs to backup, may as well just hit them all..
-dbs=$(echo 'show databases' | mysql )
+dbs=$(echo 'show databases' | mysql --defaults-file=$DEFAULTS_FILE )
 
 # Apply default filters
 db_filter='Database information_schema performance_schema'
@@ -150,14 +150,14 @@ do
     fi
 
     # create the backup for $db
-    echo "Running: mysqldump --force --opt --routines --triggers --max_allowed_packet=250M $db | $BKUP_BIN > $backupDir/$backupFile"
+    echo "Running: mysqldump --defaults-file=$DEFAULTS_FILE $db | $BKUP_BIN > $backupDir/$backupFile"
 
     # Skip actual call to mysqldump in DRY mode
     if [ $DRY_MODE -eq 1 ]; then
         continue;
     fi
 
-    mysqldump --force --opt --routines --triggers --max_allowed_packet=250M "$db" | $BKUP_BIN > "$backupDir/$backupFile"
+    mysqldump --defaults-file=$DEFAULTS_FILE "$db" | $BKUP_BIN > "$backupDir/$backupFile"
     echo
 done
 


### PR DESCRIPTION
1. Moved environment variables into a config file.
- Edits are made to config files and not the script.
2. Moved MySQL credentials into a standard my.cnf file referred to by DEFAULTS_FILE variable.
- MySQL Connection and Credential information is separated and secured.
- mysql and mysqldump commands are called with --defaults-file=$DEFAULTS_FILE
- Passwords no longer appear in ps output that includes full command line.
